### PR TITLE
Update CapacitorUrlRequest.swift fixing issue 6748

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -127,14 +127,11 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
                 data.append("\r\n".data(using: .utf8)!)
 
                 data.append(Data(base64Encoded: value)!)
-
-                data.append("\r\n".data(using: .utf8)!)
             } else if type == "string" {
                 data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
                 data.append("Content-Disposition: form-data; name=\"\(key!)\"\r\n".data(using: .utf8)!)
                 data.append("\r\n".data(using: .utf8)!)
                 data.append(value.data(using: .utf8)!)
-                data.append("\r\n".data(using: .utf8)!)
             }
 
         }


### PR DESCRIPTION
Removed non-standard blank line between field value and boundary delimiter per https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2